### PR TITLE
Add Parallel Computing and Elsevier in abbrv.bib

### DIFF
--- a/share/abbrv.bib
+++ b/share/abbrv.bib
@@ -77,6 +77,7 @@
 @string{ams-address = {Providence, Rhode-Island, USA}}
 @string{cup = {Cambridge University Press}}
 @string{cup-address = {Cambridge, England}}
+@string{elsevier = {Elsevier}}
 @string{freeman = {W. H. Freeman and Company}}
 @string{freeman-address = {New York and San Francisco}}
 @string{kluwer = {Kluwer Academic Publishers}}

--- a/share/abbrv.bib
+++ b/share/abbrv.bib
@@ -52,6 +52,7 @@
 @string{or = {Operations Research}}
 @string{orl = {Operations Research Letters}}
 @string{orsajoc = {ORSA J. of Computing}}
+@string{pc = {Parallel Comput.}}
 @string{qam = {Q. Appl. Math.}}
 @string{rairo-mm = {RAIRO-Mathematical Modelling and Numerical Analysis---Mod\'{e}lisation Math\'{e}matique et Analyse Num\'{e}rique}}
 @string{rairo-or = {RAIRO-Recherche Op\'{e}rationnelle---Operations Research}}


### PR DESCRIPTION
I will use it for the following reference:
```
@article{duff-scott-2005,
  title     = {Stabilized bordered block diagonal forms for parallel sparse solvers},
  author    = {Duff, Iain S and Scott, Jennifer A},
  journal   = {Parallel Computing},
  volume    = {31},
  number    = {3-4},
  pages     = {275--289},
  year      = {2005},
  doi       = {10.1016/j.parco.2004.12.008},
  publisher = {Elsevier}
}
```