### PR TITLE
add \cahieryear command

### DIFF
--- a/styles/common/latex_styles_common.sty
+++ b/styles/common/latex_styles_common.sty
@@ -8,7 +8,8 @@
 % Tech report number to go at top of first page.
 %
 \def\cahierline{\gdef\@cahierline}
-\cahierline{\textcolor{gray}{Cahier du GERAD G-\number\year-\cahiernumber}}
+\def\cahieryear{\year}
+\cahierline{\textcolor{gray}{Cahier du GERAD G-\number\cahieryear-\cahiernumber}}
 %
 % Git info line.
 %


### PR DESCRIPTION
It is useful for \cahieryear to not be the same as \year when revising documents that received a number on a previous year.