### PR TITLE
update build workflows

### DIFF
--- a/github-workflows/build-latex-diff.yml
+++ b/github-workflows/build-latex-diff.yml
@@ -22,6 +22,7 @@ jobs:
         id: compileLaTeXdiff
         uses: xu-cheng/latex-action@v3
         with:
+          texlive_version: 2023
           root_file: |
             ${{ env.PAPER }}-diff${{ env.MAIN }}.tex
           working_directory: paper
@@ -42,7 +43,7 @@ jobs:
             paper/${{ env.PAPER }}-diff${{ env.MAIN }}.pdf
       - name: Upload build logs
         if: steps.compileLaTeXdiff.outcome == 'failure'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Diff-Build-Failed--Here-are-the-Logs
           path: |

--- a/github-workflows/build-latex.yml
+++ b/github-workflows/build-latex.yml
@@ -38,7 +38,7 @@ jobs:
         continue-on-error: true
       - name: Upload PDF
         if: steps.compileLaTeXdocument.outcome == 'success'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Success--Here-is-the-PDF
           path: |
@@ -53,3 +53,29 @@ jobs:
       - name: Fail job if build failed
         if: steps.compileLaTeXdocument.outcome == 'failure'
         run: exit 1
+      - name: Create release
+        if: github.event_name == 'push'
+        uses: rymndhng/release-on-push-action@master
+        id: release
+        with:
+          # add a label to your pull request to change the default behavior:
+          # release:major
+          # release:minor
+          # release:patch
+          # norelease
+          bump_version_scheme: patch
+          tag_prefix: v
+          release_body: ""
+          use_github_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload PDF to release
+        if: github.event_name == 'push'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: paper/${{ env.PAPER }}.pdf
+          asset_name: ${{ env.PAPER }}.pdf
+          tag: ${{ steps.release.outputs.tag_name }}
+          overwrite: true
+          body: ""


### PR DESCRIPTION
- use upload-artifact v4
- publish pdf as release on push
- use texlive 2023 to produce diff (the action is broken with texlive 2024 and pre_compile commands)